### PR TITLE
Feature/wait for service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshine/kafka:0.10.2.0
 
-MAINTAINER Luis David Barrios Alfonso (luisdavid.barrios@agsnasoft.com / cyberluisda@gmail.com)
+MAINTAINER Luis David Barrios Alfonso (cyberluisda@gmail.com)
 
 ADD files/kafka-ctl.sh /bin/
 RUN chmod a+x /bin/kafka-ctl.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,10 @@ MAINTAINER Luis David Barrios Alfonso (cyberluisda@gmail.com)
 ADD files/kafka-ctl.sh /bin/
 RUN chmod a+x /bin/kafka-ctl.sh
 
+#Add dockerize tool
+ENV DOCKERIZE_VERSION v0.5.0
+RUN curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    | tar -C /usr/local/bin -xzvf -
+
 ENTRYPOINT ["/bin/kafka-ctl.sh"]
 CMD ["--help"]

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2.1'
 services:
   kafka-ctl:
     build: ..
+    environment:
+      WAIT_FOR_SERVICE_UP: "tcp://kafka:9092 tcp://zookeeper:2181"
     depends_on:
       kafka:
         condition: service_started

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -54,6 +54,16 @@ kafka-ctl COMMAND [options]
       NAME : name of the topic to consume data
       --file|-f filepath file to use as data input, if it is not defined data will be read from stdin
       --property PROPx=VALUEx : set property PROPx with value VALUEx in producer
+
+  ENVIRONMENT CONFIGURATION.
+    There are some configuration and behaviours that can be set using next Environment
+    Variables:
+
+      ZOOKEEPER_ENTRY_POINT. Define zookeeper entry point. By default: zookeeper:2181
+
+      KAFKA_BROKER_LIST. Define kafka bootstrap server entry points. By default:
+      kafka:9092
+
 EOF
 
 }

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -4,6 +4,9 @@ set -e
 # Common configuration
 ZOOKEEPER_ENTRY_POINT="${ZOOKEEPER_ENTRY_POINT:-zookeeper:2181}"
 KAFKA_BROKER_LIST="${KAFKA_BROKER_LIST:-kafka:9092}"
+# Only for get listed here.
+WAIT_FOR_SERVICE_UP="${WAIT_FOR_SERVICE_UP}"
+WAIT_FOR_SERVICE_UP_TIMEOUT="${WAIT_FOR_SERVICE_UP_TIMEOUT:-10s}"
 
 usage() {
   cat <<EOF
@@ -182,6 +185,20 @@ produce() {
   esac
   cat $inputFile | kafka-console-producer.sh $@ --topic "$name" --broker-list "${KAFKA_BROKER_LIST}"
 }
+
+wait_for_service_up(){
+    if [ -n "$WAIT_FOR_SERVICE_UP" ]; then
+      local services=""
+      #Set -wait option to use with docerize
+      for service in $WAIT_FOR_SERVICE_UP; do
+        services="$services -wait $service"
+      done
+      echo "Waiting till services $WAIT_FOR_SERVICE_UP is running (or timeout: $WAIT_FOR_SERVICE_UP_TIMEOUT)"
+      dockerize $services -timeout "$WAIT_FOR_SERVICE_UP_TIMEOUT"
+    fi
+}
+
+wait_for_service_up
 
 case $1 in
   list-topics)

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -65,7 +65,22 @@ kafka-ctl COMMAND [options]
       ZOOKEEPER_ENTRY_POINT. Define zookeeper entry point. By default: zookeeper:2181
 
       KAFKA_BROKER_LIST. Define kafka bootstrap server entry points. By default:
-      kafka:9092
+        kafka:9092
+
+      WAIT_FOR_SERVICE_UP. If it is defined we wait (using dockerize) for service(s)
+        to be started before to perform any operation. Example values:
+
+        WAIT_FOR_SERVICE_UP="tcp://kafka:9092" wait for tcp connection to kafka:9092
+        are available
+
+        WAIT_FOR_SERVICE_UP="tcp://kafka:9092 tcp://zookeeper:2181" Wait for
+        kafka:9092 and zookeeper:2818 connections are avilable.
+
+        If one of this can not be process will exit with error will be. See
+        https://github.com/jwilder/dockerize for more information.
+
+      WAIT_FOR_SERVICE_UP_TIMEOUT. Set timeot when check services listed on
+        WAIT_FOR_SERVICE_UP. Default value 10s
 
 EOF
 

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -208,7 +208,7 @@ wait_for_service_up(){
       for service in $WAIT_FOR_SERVICE_UP; do
         services="$services -wait $service"
       done
-      echo "Waiting till services $WAIT_FOR_SERVICE_UP is running (or timeout: $WAIT_FOR_SERVICE_UP_TIMEOUT)"
+      echo "Waiting till services $WAIT_FOR_SERVICE_UP are accessible (or timeout: $WAIT_FOR_SERVICE_UP_TIMEOUT)"
       dockerize $services -timeout "$WAIT_FOR_SERVICE_UP_TIMEOUT"
     fi
 }


### PR DESCRIPTION
Now you can configure with WAIT_FOR_SERVICE_UP environment var some services (using dockerize) to connect just before any operation. 
See Usage (run without params) for more information