### PR TITLE
Feature/create topic brokers assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with other services that require topics are created. Obviously you will need
 `healthcheck` options in docker-compose and use `depends_on: service_healthy`
 option.
 
-````
+```
 cd docker-compose
 docker-compose run -e KEEP_ALIVE_SLEEP_TIME=60 --rm kafka-ctl create-topic testtopic
 ```
@@ -54,3 +54,12 @@ docker-compose run -e KEEP_ALIVE_SLEEP_TIME=60 --rm kafka-ctl create-topic testt
 ## Cleaning procedure ##
 
 **TODO**
+
+# Multi kafka broker
+
+In same way there is `doker-compose` file in project:
+[docker-compose-multibroker.yml](./docker-compose/docker-compose-multibroker.yml)
+with 3 Kafka brokers configured.
+
+This can be usefully, for example, when you need to run `create-topic` command
+but select in which brokers you need to create.

--- a/docker-compose/docker-compose-multibroker.yml
+++ b/docker-compose/docker-compose-multibroker.yml
@@ -1,0 +1,30 @@
+# Multibroker version based on https://github.com/wurstmeister/kafka-docker/blob/master/docker-compose.yml
+---
+version: '2.2'
+services:
+  kafka-ctl:
+    build: ..
+    environment:
+      WAIT_FOR_SERVICE_UP: "tcp://kafka:9092 tcp://zookeeper:2181"
+    depends_on:
+      kafka:
+        condition: service_started
+  kafka:
+    image: openshine/kafka:0.11.0.0
+    scale: 3
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+
+    depends_on:
+      zookeeper:
+        condition: service_started
+    healthcheck:
+      test: "netstat -plnt | fgrep ':9092'"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  zookeeper:
+    image: wurstmeister/zookeeper

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -287,6 +287,26 @@ create_topics() {
     esac
     shift
   done
+
+# Return element like a circular array from CSV string.
+# Based on resolve module of index
+##
+# $1 string that will be split into array
+# $2 offset
+# $3 Optional separator to split array by default ','
+_circular_csv() {
+  local separator=","
+  if [ -n "$3" ]
+  then
+    separator="$3"
+  fi
+  IFS="$separator" read -r -a target <<< "$1"
+  local length=${#target[*]}
+  local offset=$2
+  local idx=$((offset % length))
+
+  # Return item
+  echo -n ${target[idx]}
 }
 
 # Return number of items from CSV string.

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -275,6 +275,33 @@ create_topics() {
         if [ "$safe" == "yes" ]
         then
           if kafka-topics.sh --describe --topic "$name" --zookeeper "${ZOOKEEPER_ENTRY_POINT}" 2>&1 | fgrep "$name" > /dev/null
+
+# Help function to simplify create_topic generic
+##
+# $1 safe mode?. Yes or no
+# $2 topic name
+# $3 partitions
+# $4 replication factor
+# $5 configs. Expected format is all in one string. Example '--config a=b --config c=j'
+_create_topic_all_brokers(){
+  local safe="$1"
+  local name="$2"
+  local partitions="$3"
+  local repl_fct="$4"
+  local configs="$5"
+  if [ "$safe" == "yes" ]
+  then
+    if kafka-topics.sh --describe --topic "$name" --zookeeper "${ZOOKEEPER_ENTRY_POINT}" 2>&1 | fgrep "$name" > /dev/null
+    then
+      echo "Topic $name exists. Ignoring"
+    else
+      kafka-topics.sh --create --topic "$name" --replication-factor "$repl_fct" --partitions "${partitions}" $configs --zookeeper "${ZOOKEEPER_ENTRY_POINT}"
+    fi
+  else
+    kafka-topics.sh --create --topic "$name" --replication-factor "$repl_fct" --partitions "${partitions}" $configs --zookeeper "${ZOOKEEPER_ENTRY_POINT}"
+  fi
+}
+
           then
             echo "Topic $name exists. Ignoring"
           else

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -30,7 +30,7 @@ kafka-ctl COMMAND [options]
     options : NAME0 ... NAMEn
       NAMEx : the name of topic
   create-topic : create one or more topics
-    options : [--min-num-brokers-up NUM_BROKERS] [-s|-ns] [-r REPLICATION_FACTOR0 ] [-p PARTITIONS0] [-nc] [-c CONFIG0_1 ... -c CONFIG0_n] NAME0 ... [-s] [-r REPLICATION_FACTORn ] [-p PARTITIONSn] [-nc] [-c CONFIGn_1 ... -c CONFIGn_n] NAMEn
+    options : [--min-num-brokers-up NUM_BROKERS] [-s|-ns] [-r REPLICATION_FACTOR0 ] [-p PARTITIONS0] [-b BROKER_IDS0] [-nb] [-bs] [-nbs] [-nc] [-c CONFIG0_1 ... -c CONFIG0_n] NAME0 ... [-s] [-r REPLICATION_FACTORn ] [-p PARTITIONSn] [-b BROKER_IDSn] [-nb] [-bs] [-nbs] [-nc] [-c CONFIGn_1 ... -c CONFIGn_n] NAMEn
       --min-num-brokers-up. If present create topics will be launched only if
         number of kafka brokers is greather or equal that NUM_BROKERS.
         See list-brokers -n for more information
@@ -38,6 +38,18 @@ kafka-ctl COMMAND [options]
       -s : If active (present) only create topic if not exists (-ns inverse)
       REPLICATION_FACTORx : replication factor used. Default 1
       PARTITIONSx : number of partitions. Default 1
+      BROKER_IDSx : Select this borkers ids to create topic only (CSV format
+        1001,1002,1007). All main partitions and replicas will be assigned to
+        kafka servers which broker id is in this lits in circular order.
+        Note that this options is passed to next topic description, if you set
+        for first topic and you want deactivate in next topics, you must set -nb
+        option. For example
+          create-topic -p 15 -b 0,1 topic1 -r 2 -nb topic2
+
+      -bs | -nbs. Flag (-bs activeted -nbs deactivated) that force to check each broker is up in the cluster at execution moment.
+        By default is deactivate.
+        
+      -nb Clean previous -b option.
 
       -c Override default configuration values for all topics (See kafka-config.sh for more information).
          Values are set for current topic and next. If you need reset overrided configuration values use -nc
@@ -54,7 +66,7 @@ kafka-ctl COMMAND [options]
 
       -nc Remove all CONIFx_x defined to this time
 
-      -s option, REPLICATION_FACTOR and PARTITIONS are remembered if you set they apply to next topics until you set it
+      REPLICATION_FACTOR and PARTITIONS are remembered if you set they apply to next topics until you set it
       Example create-topic -s -r 1 -p 2 topic1 topic2 is the same like
       create-topic -s -r 1 -p 2 topic1 -s -r 1 -p 2 topic2
   consume : consume and show data from a topic

--- a/files/kafka-ctl.sh
+++ b/files/kafka-ctl.sh
@@ -289,6 +289,20 @@ create_topics() {
   done
 }
 
+# Return number of items from CSV string.
+##
+# $1 string that will be split into array
+# $2 Optional separator to split array by default ','
+_length_csv(){
+  local separator=","
+  if [ -n "$2" ]
+  then
+    separator="$2"
+  fi
+  IFS="$separator" read -r -a target <<< "$1"
+
+  echo -n ${#target[@]}
+}
 consume() {
   local from_beginning="--from-beginning"
   local name="$1"


### PR DESCRIPTION
Now it is supported assign brokers ids when `create-topic`.

Command options:
* `-b`. List of broker ids to be assigned in CSV format. Example `-b 0,4,5`
* `-bs`, `-nbs`. Flag (`-bs` activated `-nbs` deactivated) to force to check each broker is up in the cluster at execution moment. By default is deactivate.
* `-nb` Clean previous -b option. Required when you create more than topic ones with Brokers assigned and others without it, but you like to list first topics with brokers assigned.